### PR TITLE
fix(seaweedfs_manager): update default workerNum

### DIFF
--- a/seaweedfs_manager.go
+++ b/seaweedfs_manager.go
@@ -689,7 +689,7 @@ func NewSeaweedFsManager(opts ...Option) (m2 Manager, err error) {
 	m := &SeaweedFsManager{
 		filerUrl:      "http://localhost:8888",
 		timeout:       5 * time.Minute,
-		workerNum:     1,
+		workerNum:     10,
 		retryInterval: 500 * time.Millisecond,
 		retryNum:      3,
 		maxQps:        5,


### PR DESCRIPTION
当crawlab一次性上传超过100个文件的文件夹时，会出现worker不够用的情况，导致部分上传代码的任务未被执行

相关bug:
https://github.com/crawlab-team/crawlab/issues/1200
https://github.com/crawlab-team/crawlab/issues/1156
https://github.com/crawlab-team/crawlab/issues/1246