### PR TITLE
添加自定义忽略文件的函数IsIgnoreFile

### DIFF
--- a/seaweedfs_manager.go
+++ b/seaweedfs_manager.go
@@ -520,7 +520,7 @@ func (m *SeaweedFsManager) syncLocalToRemote(params seaweedFsManagerParams) (res
 	// compare local files with remote files and upload files with difference
 	for _, localFile := range localFiles {
 		// skip .git
-		if IsGitFile(localFile) {
+		if IsGitFile(localFile) || IsIgnoreFile(localFile) {
 			continue
 		}
 
@@ -568,7 +568,7 @@ func (m *SeaweedFsManager) syncRemoteToLocal(params seaweedFsManagerParams) (res
 	// compare local files with remote files and delete files absent on remote
 	for _, localFile := range localFiles {
 		// skip .git
-		if IsGitFile(localFile) {
+		if IsGitFile(localFile) || IsIgnoreFile(localFile) {
 			continue
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -12,9 +12,18 @@ import (
 
 func IsGitFile(file goseaweedfs.FileInfo) (res bool) {
 	// skip .git
-	filerStr := os.Getenv("CRAWLAB_IS_GIT_FILER")
+	res, err := regexp.MatchString("/?\\.git/", file.Path)
+	if err != nil {
+		return false
+	}
+	return res
+}
+
+func IsIgnoreFile(file goseaweedfs.FileInfo) (res bool) {
+	// skip .git
+	filerStr := os.Getenv("CRAWLAB_IS_IGNORE_FILE_FILER")
 	if filerStr == "" {
-		filerStr = "/?\\.git/"
+		return false
 	}
 	res, err := regexp.MatchString(filerStr, file.Path)
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/crawlab-team/goseaweedfs"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -11,7 +12,11 @@ import (
 
 func IsGitFile(file goseaweedfs.FileInfo) (res bool) {
 	// skip .git
-	res, err := regexp.MatchString("/?\\.git/", file.Path)
+	filerStr := os.Getenv("CRAWLAB_IS_GIT_FILER")
+	if filerStr == "" {
+		filerStr = "/?\\.git/"
+	}
+	res, err := regexp.MatchString(filerStr, file.Path)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
目前后端服务有文件夹同步
会创建 .nfs前缀临时文件
这样会导致FS文件同步的时候会报错 
.nfs00000000447fd8ed000000b6: device or resource busy
因此FS同步的时候需要排除一些自定义前缀的文件
参考IsGitFile函数添加IsIgnoreFile函数,并可以通过环境变量进行配置
以实现排除 .nfs 前缀的文件

```
2023-08-02T12:18:37.205470895+08:00 remove /data/crawlab_workspace_bj_master/6489783dcb3613f0750b8387/.nfs00000000447fd8ed000000b6: device or resource busy

2023-08-02T12:18:37.205476083+08:00 /go/pkg/mod/github.com/crawlab-team/go-trace@v0.1.1/trace.go:6 github.com/crawlab-team/go-trace.PrintError()

2023-08-02T12:18:37.205478921+08:00 /go/pkg/mod/github.com/crawlab-team/crawlab-fs@v0.6.0-beta.20211101.1940.0.20221218100256-a28d12756f73/seaweedfs_manager.go:335 github.com/crawlab-team/crawlab-fs.(*SeaweedFsManager).error()

2023-08-02T12:18:37.205481407+08:00 /go/pkg/mod/github.com/crawlab-team/crawlab-fs@v0.6.0-beta.20211101.1940.0.20221218100256-a28d12756f73/seaweedfs_manager.go:584 github.com/crawlab-team/crawlab-fs.(*SeaweedFsManager).syncRemoteToLocal()

2023-08-02T12:18:37.205483437+08:00 /go/pkg/mod/github.com/crawlab-team/crawlab-fs@v0.6.0-beta.20211101.1940.0.20221218100256-a28d12756f73/seaweedfs_manager.go:309 github.com/crawlab-team/crawlab-fs.(*SeaweedFsManager).start.func1.1()

2023-08-02T12:18:37.205485264+08:00 /go/pkg/mod/github.com/cenkalti/backoff/v4@v4.1.0/retry.go:55 github.com/cenkalti/backoff/v4.RetryNotifyWithTimer()

2023-08-02T12:18:37.205486743+08:00 /go/pkg/mod/github.com/cenkalti/backoff/v4@v4.1.0/retry.go:34 github.com/cenkalti/backoff/v4.RetryNotify()

2023-08-02T12:18:37.205488282+08:00 /go/pkg/mod/github.com/cenkalti/backoff/v4@v4.1.0/retry.go:28 github.com/cenkalti/backoff/v4.Retry()

2023-08-02T12:18:37.205489877+08:00 /go/pkg/mod/github.com/crawlab-team/crawlab-fs@v0.6.0-beta.20211101.1940.0.20221218100256-a28d12756f73/seaweedfs_manager.go:308 github.com/crawlab-team/crawlab-fs.(*SeaweedFsManager).start.func1()
```